### PR TITLE
Fix: missing jwt for edit profile url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustauthx",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,9 @@ export class AuthLiteClient {
     else throw new Error('Must provide org_id');
   }
 
-  generateEditUserUrl(accessToken: string, url: string): string {
+  async generateEditUserUrl(accessToken: string, url: string): Promise<string> {
     if (!this.signedKey) {
-      throw Error('JWT Token Not Available');
+      this.signedKey = await this.getEncodedJWT();
     }
     const params = new URLSearchParams({
       AccessToken: accessToken,
@@ -80,7 +80,7 @@ export class AuthLiteClient {
         throw new Error(
           `Request failed with status code: ${
             response.status
-          }\n${await response.text()}`,
+          }\n${await response.text()}`
         );
       }
     } catch (error) {
@@ -120,7 +120,7 @@ export class AuthLiteClient {
         throw new Error(
           `Request failed with status code: ${
             response.status
-          }\n${await response.text()}`,
+          }\n${await response.text()}`
         );
       }
     } catch (error) {
@@ -152,7 +152,7 @@ export class AuthLiteClient {
         throw new Error(
           `Request failed with status code: ${
             response.status
-          }\n${await response.text()}`,
+          }\n${await response.text()}`
         );
       }
     } catch (error: any) {
@@ -187,7 +187,7 @@ export class AuthLiteClient {
   async revokeToken(
     accessToken: string,
     refreshToken: string | null = null,
-    revokeAllTokens: boolean = false,
+    revokeAllTokens: boolean = false
   ): Promise<boolean> {
     const url = 'https://api.trustauthx.com/api/user/me/token/';
     const headers = { accept: 'application/json' };
@@ -258,7 +258,7 @@ export class AuthLiteClient {
         throw new Error(
           `Request failed with status code: ${
             response.status
-          }\n${await response.text()}`,
+          }\n${await response.text()}`
         );
       }
     } catch (error) {
@@ -268,7 +268,7 @@ export class AuthLiteClient {
 
   async validateTokenSet(
     access_token: string,
-    refresh_token: string,
+    refresh_token: string
   ): Promise<TokenCheck> {
     try {
       const d: TokenCheck = {
@@ -280,7 +280,7 @@ export class AuthLiteClient {
       if (!is_valid) {
         if (refresh_token) {
           const new_tokens = await this.getAccessTokenFromRefreshToken(
-            refresh_token,
+            refresh_token
           );
           d.state = false;
           d.access = new_tokens['access_token'];


### PR DESCRIPTION
This PR fixes the `Error: JWT Token Not Available` when user tries to edit profile and signedKey is missing.

## Reproduce

- Get the secrets api_key, api_secret, and org_id
- Create AuthLiteClient client instance and pass secrets to constructor
```sh
  const authLiteClient = new AuthLiteClient(
    apiKey,
    apiSecret,
    orgId
  );
```
- Get Login URL and Copy the code from url and pass `signin` method
```js
    const loginURL = authLiteClient.generateUrl();
    
        const setToken = (access_token: string) => {
    Cookies.set('access_token', access_token, {
      expires: 3600 * 24,
    });
  };
  
  
    const signin = async (code: string) => {
    const user = await authLiteClient.getUser(code);
    setToken(user.access_token);
  };
  
  // sigin(code)
```
- Run the following LOC
```js
    const getEditProfileURL = (token: string) => {
    return authLiteClient.generateEditUserUrl(
      token,
      'http://127.0.0.1:3535/re-auth'
    );
  };
  // getEditProfileURL(token)
  ```
## Video Reference

https://github.com/One-Click-Auth/Trustauthx_TS_SDK/assets/29247011/826118fe-6dd1-43cc-9645-809d9bfb0126

## Post Merge
- Post Merge of this PR, a small change will be require in NextJs Template.